### PR TITLE
feat: enrich Vaud companies with officer and shareholder data

### DIFF
--- a/functions/src/scrapers/vaud.ts
+++ b/functions/src/scrapers/vaud.ts
@@ -98,14 +98,19 @@ export class VaudClient {
     return res.json() as Promise<T>;
   }
 
-  /** Look up the internal hrcentId for a given formatted UID (CHE-XXX.XXX.XXX). */
-  private async getHrcentId(uid: string): Promise<string | null> {
+  /**
+   * Look up the internal hrcentId by searching company name and matching the UID.
+   * The quick-search endpoint only accepts company names, not UIDs directly.
+   */
+  private async getHrcentId(name: string, uid: string): Promise<string | null> {
     const results = await this.post<VaudSearchResult[]>("/companies/quick-search", {
-      criteria: uid,
+      criteria: name,
       lang: "FR",
-      maxResultNumber: 1,
+      maxResultNumber: 10,
     });
-    return results[0]?.hrcentId ?? null;
+    // Match by UID to avoid false positives from similar company names
+    const match = results.find((r) => r.uid === uid);
+    return match?.hrcentId ?? null;
   }
 
   /** Fetch the full extract JSON for a company. */
@@ -143,9 +148,9 @@ export class VaudClient {
       return null;
     }
 
-    const hrcentId = await this.getHrcentId(uidOfs);
+    const hrcentId = await this.getHrcentId(company.name, uidOfs);
     if (!hrcentId) {
-      logger.warn(`VaudClient: hrcentId not found for ${uidOfs}`);
+      logger.warn(`VaudClient: hrcentId not found for ${company.name} (${uidOfs})`);
       return null;
     }
 

--- a/functions/src/scrapers/vaud.ts
+++ b/functions/src/scrapers/vaud.ts
@@ -1,0 +1,184 @@
+/**
+ * Vaud cantonal register client.
+ *
+ * Calls the JSON API behind https://prestations.vd.ch/pub/101266/
+ * to retrieve current officers (adms) and shareholders (associés for SARL).
+ *
+ * Auth flow:
+ *   1. GET /api/public/catalog/configuration  → receives XSRF-TOKEN cookie
+ *   2. POST requests carry that cookie + X-XSRF-TOKEN header
+ */
+
+import { logger } from "firebase-functions/v2";
+import { CompanyFull, CantonalEnrichment, Officer, Shareholder } from "@swiss-biz-hunter/types";
+
+const BASE_URL = "https://prestations.vd.ch/pub/101266/api/public";
+const REFERER = "https://prestations.vd.ch/pub/101266/";
+
+/** Raw entry from the /hrcexcerpts/ adms array */
+interface VaudAdm {
+  codeEtat: "A" | "R";
+  pers: string;
+  fonction?: string;
+  sign?: string;
+  fcdAss?: string;  // share description for associés (SARL shareholders)
+  noReference: number;
+}
+
+/** Minimal shape of the /hrcexcerpts/ response we care about */
+interface VaudExtract {
+  adms: VaudAdm[];
+}
+
+/** Minimal shape of a /companies/quick-search result line */
+interface VaudSearchResult {
+  hrcentId: string;
+  uid: string;
+}
+
+function stripHtml(str: string): string {
+  return str.replace(/<[^>]+>/g, "").trim();
+}
+
+export class VaudClient {
+  private xsrfToken: string | null = null;
+  private sessionCookie: string | null = null;
+
+  /** Initialise (or refresh) the XSRF session. */
+  async init(): Promise<void> {
+    const res = await fetch(`${BASE_URL}/catalog/configuration`, {
+      headers: { Accept: "application/json", Referer: REFERER },
+    });
+
+    if (!res.ok) {
+      throw new Error(`VaudClient init failed: ${res.status}`);
+    }
+
+    // Extract XSRF-TOKEN from Set-Cookie
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    const match = setCookie.match(/XSRF-TOKEN=([^;]+)/);
+    if (!match) throw new Error("VaudClient: no XSRF-TOKEN in Set-Cookie");
+    this.xsrfToken = match[1];
+
+    // Build the session cookie string to send back
+    // Collect all cookies (XSRF-TOKEN + session token)
+    this.sessionCookie = setCookie
+      .split(/,(?=[^ ])/)                 // split multiple Set-Cookie headers
+      .map((c) => c.split(";")[0].trim()) // keep only name=value pairs
+      .join("; ");
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    if (!this.xsrfToken) await this.init();
+
+    const res = await fetch(`${BASE_URL}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Referer: REFERER,
+        Cookie: this.sessionCookie ?? "",
+        "X-XSRF-TOKEN": this.xsrfToken ?? "",
+      },
+      body: JSON.stringify(body),
+    });
+
+    // Re-auth once on 403
+    if (res.status === 403) {
+      logger.warn("VaudClient: 403 received, refreshing session");
+      this.xsrfToken = null;
+      await this.init();
+      return this.post<T>(path, body);
+    }
+
+    if (!res.ok) {
+      throw new Error(`VaudClient POST ${path} failed: ${res.status}`);
+    }
+
+    return res.json() as Promise<T>;
+  }
+
+  /** Look up the internal hrcentId for a given formatted UID (CHE-XXX.XXX.XXX). */
+  private async getHrcentId(uid: string): Promise<string | null> {
+    const results = await this.post<VaudSearchResult[]>("/companies/quick-search", {
+      criteria: uid,
+      lang: "FR",
+      maxResultNumber: 1,
+    });
+    return results[0]?.hrcentId ?? null;
+  }
+
+  /** Fetch the full extract JSON for a company. */
+  private async getExtract(hrcentId: string, uid: string): Promise<VaudExtract | null> {
+    try {
+      return await this.post<VaudExtract>("/hrcexcerpts/", {
+        rcentId: hrcentId,
+        lng: "FR",
+        rad: true,
+        companyOfsUid: uid,
+        extraitTravail: false,
+        admOrderDirection: "ASC",
+        order: "F",
+      });
+    } catch (err) {
+      logger.warn(`VaudClient: extract fetch failed for ${uid}: ${err}`);
+      return null;
+    }
+  }
+
+  /**
+   * Enrich a Vaud company with officer and shareholder data.
+   * Returns null if enrichment is not possible (missing URL, API error, etc.).
+   */
+  async enrichCompany(company: CompanyFull): Promise<CantonalEnrichment | null> {
+    if (!company.cantonalExcerptWeb) return null;
+
+    // Extract the formatted UID (CHE-XXX.XXX.XXX) from the cantonal URL
+    let uidOfs: string;
+    try {
+      const url = new URL(company.cantonalExcerptWeb);
+      uidOfs = url.searchParams.get("companyOfsUid") ?? "";
+      if (!uidOfs) return null;
+    } catch {
+      return null;
+    }
+
+    const hrcentId = await this.getHrcentId(uidOfs);
+    if (!hrcentId) {
+      logger.warn(`VaudClient: hrcentId not found for ${uidOfs}`);
+      return null;
+    }
+
+    const extract = await this.getExtract(hrcentId, uidOfs);
+    if (!extract) return null;
+
+    const activeAdms = (extract.adms ?? []).filter((a) => a.codeEtat === "A");
+    const officers: Officer[] = [];
+    const shareholders: Shareholder[] = [];
+
+    for (const entry of activeAdms) {
+      const name = stripHtml(entry.pers);
+      const role = (entry.fonction ?? "").trim();
+
+      if (role.includes("associé")) {
+        const sharesRaw = entry.fcdAss?.trim() ?? "";
+        // fcdAss looks like ", avec 5 parts de CHF 360" — strip leading comma
+        const shares = sharesRaw.replace(/^,\s*/, "") || undefined;
+        shareholders.push({ name, shares });
+      } else {
+        officers.push({
+          name,
+          role: role || "—",
+          ...(entry.sign ? { signatureType: entry.sign } : {}),
+        });
+      }
+    }
+
+    return {
+      officers,
+      shareholders,
+      source: company.cantonalExcerptWeb,
+      enrichedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/functions/src/sync/sync.ts
+++ b/functions/src/sync/sync.ts
@@ -3,8 +3,9 @@ import { defineString } from "firebase-functions/params";
 import { getFirestore, WriteBatch } from "firebase-admin/firestore";
 import { initializeApp } from "firebase-admin/app";
 import { ZefixClient } from "../zefix/client";
-import { CompanyFull, CompanyShort, CANTONS, CANTON_SCHEDULE } from "@swiss-biz-hunter/types";
+import { CompanyFull, CompanyShort, CANTONS, CANTON_SCHEDULE, CantonalEnrichment } from "@swiss-biz-hunter/types";
 import { logger } from "firebase-functions/v2";
+import { VaudClient } from "../scrapers/vaud";
 
 initializeApp();
 
@@ -112,6 +113,15 @@ export async function syncCompaniesForCanton(
   canton: string
 ): Promise<number> {
   const db = getFirestore();
+  const vaudClient = canton === "VD" ? new VaudClient() : null;
+  if (vaudClient) {
+    try {
+      await vaudClient.init();
+      logger.info("Canton VD: VaudClient session initialized");
+    } catch (err) {
+      logger.warn(`Canton VD: VaudClient init failed, enrichment disabled: ${err}`);
+    }
+  }
 
   const seen = new Set<number>();
   const companies: CompanyShort[] = [];
@@ -145,10 +155,22 @@ export async function syncCompaniesForCanton(
     }
 
     const trimmed = trimCompanyForFirestore(full);
+
+    let cantonalEnrichment: CantonalEnrichment | undefined;
+    if (vaudClient && full.cantonalExcerptWeb) {
+      try {
+        cantonalEnrichment = (await vaudClient.enrichCompany(full)) ?? undefined;
+        await new Promise((r) => setTimeout(r, 200)); // rate limit
+      } catch (err) {
+        logger.warn(`Canton VD: enrichment failed for ${full.uid}: ${err}`);
+      }
+    }
+
     const docRef = db.collection("companies").doc(trimmed.uid);
     batch.set(docRef, {
       ...trimmed,
       syncedAt: new Date(),
+      ...(cantonalEnrichment ? { cantonalEnrichment } : {}),
     });
 
     batchCount++;

--- a/functions/src/zefix/client.test.ts
+++ b/functions/src/zefix/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type MockInstance } from "vitest";
 import { ZefixClient, ZefixApiError } from "./client";
 import type { CompanyShort, CompanyFull, LegalForm } from "@swiss-biz-hunter/types";
 
@@ -62,7 +62,8 @@ function makeRawResponse(body: string, status: number): Response {
 }
 
 let client: ZefixClient;
-let fetchSpy: ReturnType<typeof vi.spyOn>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let fetchSpy: MockInstance<any>;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -191,7 +192,9 @@ describe("ZefixClient", () => {
 
     it("sends correct Basic Auth header", async () => {
       let capturedHeaders: HeadersInit | undefined;
-      fetchSpy.mockImplementation(async (_url, init) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fetchSpy.mockImplementation(async (...args: any[]) => {
+        const init: RequestInit | undefined = args[1];
         capturedHeaders = init?.headers;
         return makeJsonResponse([]);
       });

--- a/packages/types/src/enriched.ts
+++ b/packages/types/src/enriched.ts
@@ -1,0 +1,20 @@
+// Cantonal register enrichment types
+// Data scraped from cantonal commercial registers (e.g. prestations.vd.ch)
+
+export interface Officer {
+  name: string;
+  role: string;              // e.g. "adm. président", "gérant", "directeur", "organe de révision"
+  signatureType?: string;    // e.g. "signature individuelle", "signature collective à 2"
+}
+
+export interface Shareholder {
+  name: string;
+  shares?: string;           // e.g. "avec 5 parts de CHF 360, privilégiées quant au dividende"
+}
+
+export interface CantonalEnrichment {
+  officers: Officer[];
+  shareholders: Shareholder[];  // Non-empty only for SARL/GmbH (associés are public)
+  source: string;               // URL used to fetch data
+  enrichedAt: string;           // ISO date string
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./zefix";
+export * from "./enriched";


### PR DESCRIPTION
## Summary

- Adds `VaudClient` (`functions/src/scrapers/vaud.ts`) that calls the private JSON API behind `prestations.vd.ch` to extract officer and shareholder data from the Vaud cantonal commercial register
- Integrates enrichment into the existing Wednesday VD canton sync — no new scheduled function needed
- Adds `Officer`, `Shareholder`, `CantonalEnrichment` types to the shared types package
- Fixes pre-existing TypeScript errors in `client.test.ts`

## How it works

**API discovery:** The Vaud register is an Angular SPA backed by a REST JSON API at `https://prestations.vd.ch/pub/101266/api/public`. Auth requires a XSRF-TOKEN obtained by GETting `/catalog/configuration` first.

**Data flow per company:**
1. POST `/companies/quick-search` with the formatted UID → get internal `hrcentId`
2. POST `/hrcexcerpts/` with `hrcentId` → get full extract JSON
3. Parse `adms[]` where `codeEtat === "A"` (active entries)
   - Entries with `fonction` containing `"associé"` → `shareholders` (Sàrl only, with share count from `fcdAss`)
   - All others → `officers` with role and signature type

**Stored as** `cantonalEnrichment` field on the existing Firestore `/companies/{uid}` document.

## Test plan

- [ ] Trigger VD canton sync locally via emulator and verify Firestore documents have `cantonalEnrichment` populated
- [ ] Check a Sàrl company — `cantonalEnrichment.shareholders` should list associés with share counts
- [ ] Check a SA company — `cantonalEnrichment.shareholders` should be empty, officers populated
- [ ] Check a non-VD company — no `cantonalEnrichment` field
- [ ] Verify graceful degradation: if `prestations.vd.ch` is unreachable, sync continues without enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)