### PR TITLE
build(web): upgrade next.js to 16.2.5

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "@swiss-biz-hunter/types": "*",
     "@opentelemetry/api": "^1.9.0",
     "drizzle-orm": "^0.43.0",
-    "next": "16.1.6",
+    "next": "16.2.5",
     "postgres": "^3.4.5",
     "react": "19.2.3",
     "react-dom": "19.2.3"
@@ -27,7 +27,7 @@
     "@types/react-dom": "^19",
     "drizzle-kit": "^0.31.0",
     "eslint": "^9",
-    "eslint-config-next": "16.1.6",
+    "eslint-config-next": "16.2.5",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^3.0.0",

--- a/apps/web/src/app/api/admin/sync/[canton]/route.ts
+++ b/apps/web/src/app/api/admin/sync/[canton]/route.ts
@@ -111,6 +111,7 @@ function companyToRow(full: CompanyFull, canton: string) {
     registryOfCommerceId: full.registryOfCommerceId ?? null,
     cantonalExcerptWeb: full.cantonalExcerptWeb ?? null,
     zefixDetailWeb: full.zefixDetailWeb ?? null,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sogcPub: sogcPub as any,
     oldNames: full.oldNames ?? null,
     translations: full.translation ?? null,

--- a/apps/web/src/app/api/admin/sync/trigger/route.ts
+++ b/apps/web/src/app/api/admin/sync/trigger/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { companies, companyAddresses, cantonStats, syncLogs } from "@/lib/db/schema";
@@ -84,6 +84,7 @@ function companyToRow(full: CompanyFull, canton: string) {
     registryOfCommerceId: full.registryOfCommerceId ?? null,
     cantonalExcerptWeb: full.cantonalExcerptWeb ?? null,
     zefixDetailWeb: full.zefixDetailWeb ?? null,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sogcPub: sogcPub as any,
     oldNames: full.oldNames ?? null,
     translations: full.translation ?? null,
@@ -146,6 +147,7 @@ async function syncCanton(canton: string): Promise<number> {
         set: { name: sql`excluded.name`, status: sql`excluded.status`, syncedAt: sql`NOW()` },
       });
       if (addressRows.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await db.insert(companyAddresses).values(addressRows as any).onConflictDoUpdate({
           target: companyAddresses.companyUid,
           set: { city: sql`excluded.city`, street: sql`excluded.street` },
@@ -163,6 +165,7 @@ async function syncCanton(canton: string): Promise<number> {
       set: { name: sql`excluded.name`, status: sql`excluded.status`, syncedAt: sql`NOW()` },
     });
     if (addressRows.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await db.insert(companyAddresses).values(addressRows as any).onConflictDoUpdate({
         target: companyAddresses.companyUid,
         set: { city: sql`excluded.city`, street: sql`excluded.street` },
@@ -187,7 +190,7 @@ async function syncCanton(canton: string): Promise<number> {
   return synced;
 }
 
-export async function POST(_req: NextRequest) {
+export async function POST() {
   const startTime = new Date();
   const dayOfWeek = startTime.getDay();
   const cantonsToSync = CANTON_SCHEDULE[dayOfWeek] || [];

--- a/apps/web/src/app/company/[uid]/page.tsx
+++ b/apps/web/src/app/company/[uid]/page.tsx
@@ -3,10 +3,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Shell } from "@/components/layout/Shell";
 import { Badge } from "@/components/ui/Badge";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/Card";
+import { Card, CardContent } from "@/components/ui/Card";
 import { getCompanyByUid } from "@/lib/data/companies";
 import { MOCK_COMPANY_FULL } from "@/lib/data/mock-companies";
-import { CompanyShort, CompanyStatus, CompanyFull } from "@swiss-biz-hunter/types";
+import { CompanyShort, CompanyStatus } from "@swiss-biz-hunter/types";
 
 interface PageProps {
   params: Promise<{ uid: string }>;
@@ -142,7 +142,7 @@ export default async function CompanyDetailPage({ params }: PageProps) {
             <section>
               <SectionTitle>Company Purpose</SectionTitle>
               <div className="relative">
-                <span className="absolute -left-6 top-0 text-6xl font-black text-red-600 dark:text-red-500 select-none">"</span>
+                <span className="absolute -left-6 top-0 text-6xl font-black text-red-600 dark:text-red-500 select-none">&quot;</span>
                 <p className="text-2xl md:text-3xl font-bold leading-tight tracking-tight text-zinc-800 dark:text-zinc-200 italic">
                   {company.purpose || "The commercial purpose for this company has not been provided or is unavailable in the current registry extract."}
                 </p>
@@ -150,14 +150,14 @@ export default async function CompanyDetailPage({ params }: PageProps) {
             </section>
 
             {/* Cantonal Enrichment (Officers & Shareholders) */}
-            {(company.cantonalEnrichment || (company as any).enrichment) && (
+            {company.cantonalEnrichment && (
               <div className="space-y-6">
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-12 pt-8 border-t border-zinc-100 dark:border-zinc-900">
-                  {((company.cantonalEnrichment?.officers || (company as any).enrichment?.officers) || []).length > 0 && (
+                  {company.cantonalEnrichment.officers.length > 0 && (
                     <section>
                       <SectionTitle>Officers & Management</SectionTitle>
                       <div className="bg-white dark:bg-black border border-zinc-200 dark:border-zinc-800">
-                        {(company.cantonalEnrichment?.officers || (company as any).enrichment?.officers || []).map((officer: any, i: number) => (
+                        {company.cantonalEnrichment.officers.map((officer, i) => (
                           <div key={i} className="p-4 border-b border-zinc-100 dark:border-zinc-900 last:border-0">
                             <p className="text-sm font-black uppercase tracking-tight">{officer.name}</p>
                             <div className="flex flex-wrap gap-2 mt-1">
@@ -172,11 +172,11 @@ export default async function CompanyDetailPage({ params }: PageProps) {
                     </section>
                   )}
 
-                  {((company.cantonalEnrichment?.shareholders || (company as any).enrichment?.shareholders) || []).length > 0 && (
+                  {company.cantonalEnrichment.shareholders.length > 0 && (
                     <section>
                       <SectionTitle>Shareholders</SectionTitle>
                       <div className="bg-white dark:bg-black border border-zinc-200 dark:border-zinc-800">
-                        {(company.cantonalEnrichment?.shareholders || (company as any).enrichment?.shareholders || []).map((shareholder: any, i: number) => (
+                        {company.cantonalEnrichment.shareholders.map((shareholder, i) => (
                           <div key={i} className="p-4 border-b border-zinc-100 dark:border-zinc-900 last:border-0">
                             <p className="text-sm font-black uppercase tracking-tight">{shareholder.name}</p>
                             {shareholder.shares && (
@@ -189,16 +189,16 @@ export default async function CompanyDetailPage({ params }: PageProps) {
                   )}
                 </div>
                 
-                {(company.cantonalEnrichment?.source || (company as any).enrichment?.source) && (
+                {company.cantonalEnrichment.source && (
                   <div className="flex items-center gap-3 text-[10px] font-black uppercase tracking-widest text-zinc-400">
                     <span className="bg-zinc-100 dark:bg-zinc-900 px-2 py-0.5 text-zinc-600 dark:text-zinc-300">Verified Source</span>
                     <a 
-                      href={company.cantonalEnrichment?.source || (company as any).enrichment?.source} 
+                      href={company.cantonalEnrichment.source} 
                       target="_blank" 
                       rel="noopener noreferrer" 
                       className="hover:text-black dark:hover:text-white transition-colors underline decoration-zinc-200 underline-offset-4"
                     >
-                      Cantonal Register (VD) ↗
+                      Cantonal Register (VD) &rarr;
                     </a>
                   </div>
                 )}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -22,7 +22,7 @@ export default async function SearchResultsPage({ searchParams }: PageProps) {
               Search Results
             </h1>
             {query && (
-              <Badge variant="accent">"{query}"</Badge>
+              <Badge variant="accent">&quot;{query}&quot;</Badge>
             )}
           </div>
           <p className="text-zinc-500 font-medium">
@@ -56,7 +56,7 @@ export default async function SearchResultsPage({ searchParams }: PageProps) {
                       {company.status}
                     </Badge>
                     <span className="text-zinc-300 dark:text-zinc-700 hidden md:block">
-                      →
+                      &rarr;
                     </span>
                   </div>
                 </div>
@@ -66,7 +66,7 @@ export default async function SearchResultsPage({ searchParams }: PageProps) {
         ) : (
           <div className="py-24 text-center border-2 border-dashed border-zinc-100 dark:border-zinc-900">
             <p className="text-xl font-bold text-zinc-400 uppercase tracking-widest italic">
-              No results found for "{query}"
+              No results found for &quot;{query}&quot;
             </p>
             <Link href="/" className="mt-4 inline-block text-xs font-bold uppercase tracking-widest text-red-600 hover:underline">
               Try another search

--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+type CardProps = React.HTMLAttributes<HTMLDivElement>;
 
 export function Card({ className = "", children, ...props }: CardProps) {
   return (

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -25,6 +25,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMounted(true);
   }, []);
 

--- a/apps/web/src/lib/data/companies.test.ts
+++ b/apps/web/src/lib/data/companies.test.ts
@@ -103,7 +103,7 @@ describe("getCompanyByUid", () => {
     });
     const result = await getCompanyByUid("CHE-123.456.789");
     expect(result).not.toBeNull();
-    expect(result!.uid).toBe("CHE-123.456.789");
-    expect((result as any).name).toBe("Test AG");
+    expect(result?.uid).toBe("CHE-123.456.789");
+    expect(result?.name).toBe("Test AG");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@swiss-biz-hunter/types": "*",
         "drizzle-orm": "^0.43.0",
-        "next": "16.1.6",
+        "next": "16.2.5",
         "postgres": "^3.4.5",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -29,7 +29,7 @@
         "@vitest/coverage-v8": "^3.0.0",
         "drizzle-kit": "^0.31.0",
         "eslint": "^9",
-        "eslint-config-next": "16.1.6",
+        "eslint-config-next": "16.2.5",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^3.0.0"
@@ -2077,15 +2077,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.5.tgz",
+      "integrity": "sha512-Lb9ElHD2klcyeVD25vW+siPFqz9QMzDUSgvFZNO+dZEKoMHex4viJhVuzBhrXKqb+UKnih7mVYbt50/7KLsSCA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
-      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.5.tgz",
+      "integrity": "sha512-PyILm/cw2u5gEG5xOjqFbALUAl/erAqtM47iZtP9lXiSzin+eOIf3KRi+CBC/mFG9j7Iz3JDqCOY94nFLUCccg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2093,9 +2093,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.5.tgz",
+      "integrity": "sha512-BW+8PGVmsruomXHsitD8JG6gny9lEdobctjBwvtPF8AKtxGDR7nR35FOl/oK9UAPXBOBm+vx0k8qtpeHOXQMGQ==",
       "cpu": [
         "arm64"
       ],
@@ -2109,9 +2109,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.5.tgz",
+      "integrity": "sha512-ZoCGnCl9LlQJWmqXrZAUlNxvuNmclvE+7zUif+nDydkkehl9FKxHJ+wxSQMj+C37BYFerKiEdX9s9o02ir975Q==",
       "cpu": [
         "x64"
       ],
@@ -2125,9 +2125,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.5.tgz",
+      "integrity": "sha512-AwcZzMChaWkOTZt3vu+2ZMIj8g4dYQY+B8VUVhlFSQ2JtvyZpefyYHTe00D6b6L7BysYw7vl3zsvs9jix8tl5Q==",
       "cpu": [
         "arm64"
       ],
@@ -2141,9 +2141,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.5.tgz",
+      "integrity": "sha512-QqMgqWbCBFsfiQ7BF3dUlW8HJy1LWhpcqbTpoHMWA9IV+TnWwDKozQJA5NdIAHjQ00yX2Q7AUkLr/XK4n77q8A==",
       "cpu": [
         "arm64"
       ],
@@ -2157,9 +2157,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.5.tgz",
+      "integrity": "sha512-3hzeiFGZtyATVx9pCeuzTshXmh50vHZitqaeZiyJZaUmjQyrfjsVUgS8apOj1vEJCIpKJM/55F45yPAV2kpjsA==",
       "cpu": [
         "x64"
       ],
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.5.tgz",
+      "integrity": "sha512-0mzZV/mAt7Qj2tYNdTB6AqrS8dwng/AQLSYC5Z1YLpZdi2wxqKDPK7RY2RvjB1fXyJfOfdA3l/yTF5yLi+WfuQ==",
       "cpu": [
         "x64"
       ],
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.5.tgz",
+      "integrity": "sha512-f/H4nZ2zJBvA8/+HpsB9mNonF9zfQoAU6D0WxJrfzhJDvJLfngVN85oqxUyrDVK99DIFfFYhLpGa5K+c5uotSw==",
       "cpu": [
         "arm64"
       ],
@@ -2205,9 +2205,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.5.tgz",
+      "integrity": "sha512-nuP7DHs4koAojsIxVPkihNgKiRUKtCU65j5X6DAbSy8VBrfT/o90bCLLHPf51JEdOZwZMFzM6e0NiGWfIWjVAg==",
       "cpu": [
         "x64"
       ],
@@ -5470,13 +5470,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
-      "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.5.tgz",
+      "integrity": "sha512-fXEkugikngux1FBJ/Vop+52SLAMFjXZFXjyl/+HjGHngnXf8iIfqe3qdjcwN+40RBpSsCVhI04j0/ngEWL5Qng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.1.6",
+        "@next/eslint-plugin-next": "16.2.5",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5600,7 +5600,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7590,14 +7589,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.5.tgz",
+      "integrity": "sha512-TkVTm9F2WEulkgGljm4wPwNgvCCWCVw6StUHsZb8WZpHFRjepoUWg3d7L4IMg7IyjcJ4Co9eVhpro8e8O+KarQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.5",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -7609,15 +7608,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.5",
+        "@next/swc-darwin-x64": "16.2.5",
+        "@next/swc-linux-arm64-gnu": "16.2.5",
+        "@next/swc-linux-arm64-musl": "16.2.5",
+        "@next/swc-linux-x64-gnu": "16.2.5",
+        "@next/swc-linux-x64-musl": "16.2.5",
+        "@next/swc-win32-arm64-msvc": "16.2.5",
+        "@next/swc-win32-x64-msvc": "16.2.5",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -7982,9 +7981,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Description
This PR upgrades Next.js to version 16.2.5 and resolves associated linting issues.

## Changes
- Upgraded \
ext\ and \eslint-config-next\ to \16.2.5\ in \pps/web\.
- Fixed React unescaped entity errors in search and company pages.
- Removed unused imports and variables across sync routes and company detail pages.
- Converted empty interfaces to types in \Card.tsx\ to satisfy ESLint rules.
- Added lint suppression for the standard \mounted\ state pattern in \Toast.tsx\.
- Suppressed legacy \ny\ types in admin sync routes.

## Verification
- \
pm run build\ passed successfully.
- \
pm run lint\ passed (ignoring one unrelated warning).