### PR TITLE
refactor(web): remove explicit any and type database schema

### DIFF
--- a/apps/web/src/app/api/admin/sync/[canton]/route.ts
+++ b/apps/web/src/app/api/admin/sync/[canton]/route.ts
@@ -111,8 +111,7 @@ function companyToRow(full: CompanyFull, canton: string) {
     registryOfCommerceId: full.registryOfCommerceId ?? null,
     cantonalExcerptWeb: full.cantonalExcerptWeb ?? null,
     zefixDetailWeb: full.zefixDetailWeb ?? null,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sogcPub: sogcPub as any,
+    sogcPub: sogcPub,
     oldNames: full.oldNames ?? null,
     translations: full.translation ?? null,
     headOffices: full.headOffices ?? null,

--- a/apps/web/src/app/api/admin/sync/trigger/route.ts
+++ b/apps/web/src/app/api/admin/sync/trigger/route.ts
@@ -84,8 +84,7 @@ function companyToRow(full: CompanyFull, canton: string) {
     registryOfCommerceId: full.registryOfCommerceId ?? null,
     cantonalExcerptWeb: full.cantonalExcerptWeb ?? null,
     zefixDetailWeb: full.zefixDetailWeb ?? null,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sogcPub: sogcPub as any,
+    sogcPub: sogcPub,
     oldNames: full.oldNames ?? null,
     translations: full.translation ?? null,
     headOffices: full.headOffices ?? null,
@@ -112,7 +111,7 @@ async function syncCanton(canton: string): Promise<number> {
   console.log(`[sync] Canton ${canton}: ${discovered.length} companies`);
 
   const rows: ReturnType<typeof companyToRow>[] = [];
-  const addressRows: Array<{ companyUid: string; [key: string]: unknown }> = [];
+  const addressRows: Array<typeof companyAddresses.$inferInsert> = [];
   let synced = 0;
 
   for (const company of discovered) {
@@ -147,8 +146,7 @@ async function syncCanton(canton: string): Promise<number> {
         set: { name: sql`excluded.name`, status: sql`excluded.status`, syncedAt: sql`NOW()` },
       });
       if (addressRows.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await db.insert(companyAddresses).values(addressRows as any).onConflictDoUpdate({
+        await db.insert(companyAddresses).values(addressRows).onConflictDoUpdate({
           target: companyAddresses.companyUid,
           set: { city: sql`excluded.city`, street: sql`excluded.street` },
         });
@@ -165,8 +163,7 @@ async function syncCanton(canton: string): Promise<number> {
       set: { name: sql`excluded.name`, status: sql`excluded.status`, syncedAt: sql`NOW()` },
     });
     if (addressRows.length > 0) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await db.insert(companyAddresses).values(addressRows as any).onConflictDoUpdate({
+      await db.insert(companyAddresses).values(addressRows).onConflictDoUpdate({
         target: companyAddresses.companyUid,
         set: { city: sql`excluded.city`, street: sql`excluded.street` },
       });

--- a/apps/web/src/lib/db/schema.ts
+++ b/apps/web/src/lib/db/schema.ts
@@ -2,6 +2,9 @@ import {
   pgTable, text, integer, numeric, timestamp, jsonb, serial, index,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
+import {
+  SogcPublication, CompanyOldName, CompanyShort, DFIEString,
+} from "@swiss-biz-hunter/types";
 
 export const companies = pgTable("companies", {
   uid: text("uid").primaryKey(),
@@ -26,16 +29,16 @@ export const companies = pgTable("companies", {
   deletionDate: text("deletion_date"),
   registryOfCommerceId: integer("registry_of_commerce_id"),
   cantonalExcerptWeb: text("cantonal_excerpt_web"),
-  zefixDetailWeb: jsonb("zefix_detail_web"),
-  sogcPub: jsonb("sogc_pub"),
-  oldNames: jsonb("old_names"),
-  translations: jsonb("translations"),
-  headOffices: jsonb("head_offices"),
-  furtherHeadOffices: jsonb("further_head_offices"),
-  branchOffices: jsonb("branch_offices"),
-  hasTakenOver: jsonb("has_taken_over"),
-  wasTakenOverBy: jsonb("was_taken_over_by"),
-  auditCompanies: jsonb("audit_companies"),
+  zefixDetailWeb: jsonb("zefix_detail_web").$type<DFIEString>(),
+  sogcPub: jsonb("sogc_pub").$type<SogcPublication[]>(),
+  oldNames: jsonb("old_names").$type<CompanyOldName[]>(),
+  translations: jsonb("translations").$type<string[]>(),
+  headOffices: jsonb("head_offices").$type<CompanyShort[]>(),
+  furtherHeadOffices: jsonb("further_head_offices").$type<CompanyShort[]>(),
+  branchOffices: jsonb("branch_offices").$type<CompanyShort[]>(),
+  hasTakenOver: jsonb("has_taken_over").$type<CompanyShort[]>(),
+  wasTakenOverBy: jsonb("was_taken_over_by").$type<CompanyShort[]>(),
+  auditCompanies: jsonb("audit_companies").$type<CompanyShort[]>(),
   syncedAt: timestamp("synced_at", { withTimezone: true }).defaultNow(),
 }, (t) => [
   index("idx_companies_canton").on(t.canton),


### PR DESCRIPTION
This PR improves type safety by:
1. Adding explicit types to JSONB columns in the Drizzle schema.
2. Removing 'as any' casts and ESLint disables in the sync routes.
3. Using Drizzle's \$inferInsert\ for strictly typed database operations.